### PR TITLE
changed package and app names

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,18 +5,18 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "GraTerenowa (Release)",
+            "name": "Kompas (Release)",
             "type": "dart",
             "request": "launch",
             "flutterMode": "release",
         },
         {
-            "name": "GraTerenowa",
+            "name": "Kompas",
             "request": "launch",
             "type": "dart"
         },
         {
-            "name": "GraTerenowa (profile mode)",
+            "name": "Kompas (profile mode)",
             "request": "launch",
             "type": "dart",
             "flutterMode": "profile"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Gra Terenowa
+# kompas.sds
 ![zamek_jesien_mobile](https://user-images.githubusercontent.com/42238956/139399262-2e2ca06c-35b7-4ffe-9dd7-8fa3d9fef1b2.jpg)
 
 Outdoor game for families written in Flutter.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -35,7 +35,7 @@ android {
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId "com.example.gra_terenowa"
+        applicationId "pl.sds.kompas"
         minSdkVersion 23
         targetSdkVersion 31
         versionCode flutterVersionCode.toInteger()

--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.gra_terenowa">
+    package="pl.sds.kompas">
     <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,10 +1,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.gra_terenowa">
+    package="pl.sds.kompas">
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION"/>
    <application
-        android:label="gra_terenowa"
+        android:label="kompas.sds"
         android:icon="@mipmap/ic_launcher">
         <activity
             android:name=".MainActivity"

--- a/android/app/src/main/kotlin/pl/sds/kompas/MainActivity.kt
+++ b/android/app/src/main/kotlin/pl/sds/kompas/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.example.gra_terenowa
+package pl.sds.kompas
 
 import io.flutter.embedding.android.FlutterActivity
 

--- a/android/app/src/profile/AndroidManifest.xml
+++ b/android/app/src/profile/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.gra_terenowa">
+    package="pl.sds.kompas">
     <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -291,7 +291,7 @@
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.graTerenowa;
+				PRODUCT_BUNDLE_IDENTIFIER = pl.sds.kompas;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -415,7 +415,7 @@
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.graTerenowa;
+				PRODUCT_BUNDLE_IDENTIFIER = pl.sds.kompas;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -434,7 +434,7 @@
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.graTerenowa;
+				PRODUCT_BUNDLE_IDENTIFIER = pl.sds.kompas;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>kompas.sds</string>
+	<string>kompas</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>gra_terenowa</string>
+	<string>kompas.sds</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/lib/controller/mapData_controller.dart
+++ b/lib/controller/mapData_controller.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:gra_terenowa/controller/mapTransfer_controller.dart';
-import 'package:gra_terenowa/model/mapDatabase.dart';
-import 'package:gra_terenowa/statics/colors.dart';
+import 'package:kompas/controller/mapTransfer_controller.dart';
+import 'package:kompas/model/mapDatabase.dart';
+import 'package:kompas/statics/colors.dart';
 
 class MapDataController extends GetxController
     with GetSingleTickerProviderStateMixin {

--- a/lib/controller/mapTransfer_controller.dart
+++ b/lib/controller/mapTransfer_controller.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:gra_terenowa/statics/constants.dart';
+import 'package:kompas/statics/constants.dart';
 
 class MapTransformController extends TransformationController {
   MapTransformController() {

--- a/lib/controller/tripData_controller.dart
+++ b/lib/controller/tripData_controller.dart
@@ -2,7 +2,7 @@
 ///
 
 import 'package:get/get.dart';
-import 'package:gra_terenowa/model/tripDatabase.dart';
+import 'package:kompas/model/tripDatabase.dart';
 
 class TripDataController extends GetxController {
   /// Holds data for all available trips

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:gra_terenowa/statics/routes.dart';
-import 'package:gra_terenowa/statics/text_styles.dart';
-import 'package:gra_terenowa/view/home_screen.dart';
-import 'package:gra_terenowa/view/mapCard_screen.dart';
-import 'package:gra_terenowa/view/trip_screen.dart';
+import 'package:kompas/statics/routes.dart';
+import 'package:kompas/statics/text_styles.dart';
+import 'package:kompas/view/home_screen.dart';
+import 'package:kompas/view/mapCard_screen.dart';
+import 'package:kompas/view/trip_screen.dart';
 
 import 'statics/colors.dart';
 import 'view/selectTrip_screen.dart';
@@ -28,7 +28,7 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return GetMaterialApp(
-      title: 'GraTerenowa',
+      title: 'kompas.sds',
       theme: ThemeData.light().copyWith(
         primaryColor: AppColors.primaryNormal,
         backgroundColor: AppColors.primaryWhite,

--- a/lib/model/mapDatabase.dart
+++ b/lib/model/mapDatabase.dart
@@ -1,8 +1,8 @@
 /// This class will handle data loading from FireBase
 
 import 'package:flutter/material.dart';
-import 'package:gra_terenowa/statics/colors.dart';
-import 'package:gra_terenowa/statics/constants.dart';
+import 'package:kompas/statics/colors.dart';
+import 'package:kompas/statics/constants.dart';
 
 enum MapItemType {
   building_large,

--- a/lib/model/tripDatabase.dart
+++ b/lib/model/tripDatabase.dart
@@ -1,6 +1,6 @@
 /// This class will handle data loading from FireBase
 
-import 'package:gra_terenowa/statics/constants.dart';
+import 'package:kompas/statics/constants.dart';
 
 enum TripPropertyType {
   time,

--- a/lib/view/home_screen.dart
+++ b/lib/view/home_screen.dart
@@ -1,18 +1,18 @@
 import 'package:flutter/services.dart';
-import 'package:gra_terenowa/controller/mapData_controller.dart';
-import 'package:gra_terenowa/controller/tripState_controller.dart';
-import 'package:gra_terenowa/widgets/achievementTracker_widget.dart';
-import 'package:gra_terenowa/statics/constants.dart';
-import 'package:gra_terenowa/statics/keepAliveWrapper.dart';
-import 'package:gra_terenowa/widgets/homeView_widget.dart';
-import 'package:gra_terenowa/widgets/infoView_widget.dart';
-import 'package:gra_terenowa/widgets/mapView_widget.dart';
+import 'package:kompas/controller/mapData_controller.dart';
+import 'package:kompas/controller/tripState_controller.dart';
+import 'package:kompas/widgets/achievementTracker_widget.dart';
+import 'package:kompas/statics/constants.dart';
+import 'package:kompas/statics/keepAliveWrapper.dart';
+import 'package:kompas/widgets/homeView_widget.dart';
+import 'package:kompas/widgets/infoView_widget.dart';
+import 'package:kompas/widgets/mapView_widget.dart';
 import 'package:line_icons/line_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:gra_terenowa/controller/tripData_controller.dart';
-import 'package:gra_terenowa/statics/colors.dart';
-import 'package:gra_terenowa/widgets/tabOutlineIndicator.dart';
+import 'package:kompas/controller/tripData_controller.dart';
+import 'package:kompas/statics/colors.dart';
+import 'package:kompas/widgets/tabOutlineIndicator.dart';
 import 'package:map_launcher/map_launcher.dart';
 
 class HomePage extends StatefulWidget {

--- a/lib/view/mapCard_screen.dart
+++ b/lib/view/mapCard_screen.dart
@@ -3,9 +3,9 @@ import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get/get.dart';
-import 'package:gra_terenowa/controller/mapData_controller.dart';
-import 'package:gra_terenowa/statics/colors.dart';
-import 'package:gra_terenowa/statics/constants.dart';
+import 'package:kompas/controller/mapData_controller.dart';
+import 'package:kompas/statics/colors.dart';
+import 'package:kompas/statics/constants.dart';
 
 class MapCardPage extends StatelessWidget {
   const MapCardPage({

--- a/lib/view/selectTrip_screen.dart
+++ b/lib/view/selectTrip_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:gra_terenowa/controller/tripData_controller.dart';
-import 'package:gra_terenowa/statics/constants.dart';
+import 'package:kompas/controller/tripData_controller.dart';
+import 'package:kompas/statics/constants.dart';
 
 class SelectTripPage extends StatelessWidget {
   const SelectTripPage({

--- a/lib/view/trip_screen.dart
+++ b/lib/view/trip_screen.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get/get.dart';
-import 'package:gra_terenowa/controller/tripData_controller.dart';
-import 'package:gra_terenowa/controller/tripState_controller.dart';
-import 'package:gra_terenowa/statics/colors.dart';
-import 'package:gra_terenowa/statics/routes.dart';
-import 'package:gra_terenowa/statics/constants.dart';
-import 'package:gra_terenowa/widgets/tripViewStep_widget.dart';
+import 'package:kompas/controller/tripData_controller.dart';
+import 'package:kompas/controller/tripState_controller.dart';
+import 'package:kompas/statics/colors.dart';
+import 'package:kompas/statics/routes.dart';
+import 'package:kompas/statics/constants.dart';
+import 'package:kompas/widgets/tripViewStep_widget.dart';
 import 'package:line_icons/line_icons.dart';
 
 class TripPage extends StatelessWidget {

--- a/lib/widgets/achievementTracker_widget.dart
+++ b/lib/widgets/achievementTracker_widget.dart
@@ -1,7 +1,7 @@
 import 'package:expansion_tile_card/expansion_tile_card.dart';
 import 'package:flutter/material.dart';
-import 'package:gra_terenowa/controller/tripData_controller.dart';
-import 'package:gra_terenowa/statics/colors.dart';
+import 'package:kompas/controller/tripData_controller.dart';
+import 'package:kompas/statics/colors.dart';
 import 'package:hive/hive.dart';
 
 class AchievementTracker extends StatefulWidget {

--- a/lib/widgets/cardHeroDisplay_widget.dart
+++ b/lib/widgets/cardHeroDisplay_widget.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:gra_terenowa/statics/colors.dart';
-import 'package:gra_terenowa/statics/constants.dart';
+import 'package:kompas/statics/colors.dart';
+import 'package:kompas/statics/constants.dart';
 
 class CardHeroDisplay extends StatelessWidget {
   const CardHeroDisplay({

--- a/lib/widgets/cardHero_widget.dart
+++ b/lib/widgets/cardHero_widget.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:gra_terenowa/controller/tripData_controller.dart';
-import 'package:gra_terenowa/statics/colors.dart';
-import 'package:gra_terenowa/statics/constants.dart';
-import 'package:gra_terenowa/widgets/cardHeroDisplay_widget.dart';
+import 'package:kompas/controller/tripData_controller.dart';
+import 'package:kompas/statics/colors.dart';
+import 'package:kompas/statics/constants.dart';
+import 'package:kompas/widgets/cardHeroDisplay_widget.dart';
 
 class CardHero extends StatelessWidget {
   const CardHero(

--- a/lib/widgets/gpsPoint_widget.dart
+++ b/lib/widgets/gpsPoint_widget.dart
@@ -1,9 +1,9 @@
 // TODO: GPS
 // import 'package:flutter/material.dart';
 // import 'package:get/get.dart';
-// import 'package:gra_terenowa/controller/mapData_controller.dart';
-// import 'package:gra_terenowa/model/mapDatabase.dart';
-// import 'package:gra_terenowa/statics/colors.dart';
+// import 'package:kompas/controller/mapData_controller.dart';
+// import 'package:kompas/model/mapDatabase.dart';
+// import 'package:kompas/statics/colors.dart';
 
 // class GPSPoint extends StatelessWidget {
 //   GPSPoint({

--- a/lib/widgets/homeView_widget.dart
+++ b/lib/widgets/homeView_widget.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:gra_terenowa/statics/colors.dart';
-import 'package:gra_terenowa/statics/constants.dart';
-import 'package:gra_terenowa/view/selectTrip_screen.dart';
-import 'package:gra_terenowa/widgets/selectTrip_widget.dart';
+import 'package:kompas/statics/colors.dart';
+import 'package:kompas/statics/constants.dart';
+import 'package:kompas/view/selectTrip_screen.dart';
+import 'package:kompas/widgets/selectTrip_widget.dart';
 
 import 'cardHero_widget.dart';
 

--- a/lib/widgets/infoView_widget.dart
+++ b/lib/widgets/infoView_widget.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:gra_terenowa/statics/colors.dart';
-import 'package:gra_terenowa/statics/constants.dart';
-import 'package:gra_terenowa/widgets/achievementTracker_widget.dart';
+import 'package:kompas/statics/colors.dart';
+import 'package:kompas/statics/constants.dart';
+import 'package:kompas/widgets/achievementTracker_widget.dart';
 import 'package:map_launcher/map_launcher.dart';
 
 class InfoView extends StatelessWidget {

--- a/lib/widgets/mapCardHero_widget.dart
+++ b/lib/widgets/mapCardHero_widget.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:gra_terenowa/controller/mapData_controller.dart';
-import 'package:gra_terenowa/statics/colors.dart';
-import 'package:gra_terenowa/statics/constants.dart';
-import 'package:gra_terenowa/view/mapCard_screen.dart';
+import 'package:kompas/controller/mapData_controller.dart';
+import 'package:kompas/statics/colors.dart';
+import 'package:kompas/statics/constants.dart';
+import 'package:kompas/view/mapCard_screen.dart';
 
 class MapCardHero extends StatelessWidget {
   const MapCardHero({Key? key, required this.onTap, required this.mapItemIndex})

--- a/lib/widgets/mapPoint_widget.dart
+++ b/lib/widgets/mapPoint_widget.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:gra_terenowa/controller/mapData_controller.dart';
-import 'package:gra_terenowa/controller/mapTransfer_controller.dart';
-import 'package:gra_terenowa/model/mapDatabase.dart';
-import 'package:gra_terenowa/statics/colors.dart';
-import 'package:gra_terenowa/statics/constants.dart';
+import 'package:kompas/controller/mapData_controller.dart';
+import 'package:kompas/controller/mapTransfer_controller.dart';
+import 'package:kompas/model/mapDatabase.dart';
+import 'package:kompas/statics/colors.dart';
+import 'package:kompas/statics/constants.dart';
 
 class MapPoint extends StatelessWidget {
   MapPoint({

--- a/lib/widgets/mapView_widget.dart
+++ b/lib/widgets/mapView_widget.dart
@@ -1,15 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:gra_terenowa/controller/mapData_controller.dart';
-import 'package:gra_terenowa/controller/mapTransfer_controller.dart';
-import 'package:gra_terenowa/statics/colors.dart';
-import 'package:gra_terenowa/statics/constants.dart';
+import 'package:kompas/controller/mapData_controller.dart';
+import 'package:kompas/controller/mapTransfer_controller.dart';
+import 'package:kompas/statics/colors.dart';
+import 'package:kompas/statics/constants.dart';
 // TODO: GPS
-//import 'package:gra_terenowa/widgets/gpsPoint_widget.dart';
+//import 'package:kompas/widgets/gpsPoint_widget.dart';
 //import 'package:geolocator/geolocator.dart';
-//import 'package:gra_terenowa/services/gpsService.dart';
-import 'package:gra_terenowa/widgets/mapCardHero_widget.dart';
-import 'package:gra_terenowa/widgets/mapPoint_widget.dart';
+//import 'package:kompas/services/gpsService.dart';
+import 'package:kompas/widgets/mapCardHero_widget.dart';
+import 'package:kompas/widgets/mapPoint_widget.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:line_icons/line_icons.dart';
 

--- a/lib/widgets/selectTrip_widget.dart
+++ b/lib/widgets/selectTrip_widget.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:gra_terenowa/controller/tripData_controller.dart';
-import 'package:gra_terenowa/statics/colors.dart';
-import 'package:gra_terenowa/statics/constants.dart';
-import 'package:gra_terenowa/model/tripDatabase.dart';
-import 'package:gra_terenowa/view/trip_screen.dart';
-import 'package:gra_terenowa/widgets/tripProperty_widget.dart';
+import 'package:kompas/controller/tripData_controller.dart';
+import 'package:kompas/statics/colors.dart';
+import 'package:kompas/statics/constants.dart';
+import 'package:kompas/model/tripDatabase.dart';
+import 'package:kompas/view/trip_screen.dart';
+import 'package:kompas/widgets/tripProperty_widget.dart';
 
 class SelectTrip extends StatelessWidget {
   const SelectTrip(

--- a/lib/widgets/tabOutlineIndicator.dart
+++ b/lib/widgets/tabOutlineIndicator.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:gra_terenowa/statics/colors.dart';
-import 'package:gra_terenowa/statics/constants.dart';
+import 'package:kompas/statics/colors.dart';
+import 'package:kompas/statics/constants.dart';
 
 class TabOutlineIndicator extends Decoration {
   const TabOutlineIndicator({

--- a/lib/widgets/tripProperty_widget.dart
+++ b/lib/widgets/tripProperty_widget.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:gra_terenowa/statics/colors.dart';
-import 'package:gra_terenowa/model/tripDatabase.dart';
+import 'package:kompas/statics/colors.dart';
+import 'package:kompas/model/tripDatabase.dart';
 
 class TripProperty extends StatelessWidget {
   const TripProperty({

--- a/lib/widgets/tripStepSelectBox_widget.dart
+++ b/lib/widgets/tripStepSelectBox_widget.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:gra_terenowa/controller/tripData_controller.dart';
-import 'package:gra_terenowa/controller/tripState_controller.dart';
-import 'package:gra_terenowa/statics/colors.dart';
-import 'package:gra_terenowa/statics/constants.dart';
+import 'package:kompas/controller/tripData_controller.dart';
+import 'package:kompas/controller/tripState_controller.dart';
+import 'package:kompas/statics/colors.dart';
+import 'package:kompas/statics/constants.dart';
 
 class TripStepSelectBox extends StatelessWidget {
   const TripStepSelectBox({

--- a/lib/widgets/tripViewStepButtons_widget.dart
+++ b/lib/widgets/tripViewStepButtons_widget.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:gra_terenowa/controller/tripData_controller.dart';
-import 'package:gra_terenowa/controller/tripState_controller.dart';
-import 'package:gra_terenowa/statics/colors.dart';
-import 'package:gra_terenowa/statics/constants.dart';
-import 'package:gra_terenowa/statics/routes.dart';
+import 'package:kompas/controller/tripData_controller.dart';
+import 'package:kompas/controller/tripState_controller.dart';
+import 'package:kompas/statics/colors.dart';
+import 'package:kompas/statics/constants.dart';
+import 'package:kompas/statics/routes.dart';
 
 /// Displays trip content based on step type
 class TripViewStepButtons extends StatelessWidget {

--- a/lib/widgets/tripViewStepSwitch_widget.dart
+++ b/lib/widgets/tripViewStepSwitch_widget.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:gra_terenowa/controller/tripData_controller.dart';
-import 'package:gra_terenowa/controller/tripState_controller.dart';
-import 'package:gra_terenowa/statics/colors.dart';
-import 'package:gra_terenowa/statics/constants.dart';
-import 'package:gra_terenowa/widgets/achievementTracker_widget.dart';
-import 'package:gra_terenowa/model/tripDatabase.dart';
-import 'package:gra_terenowa/widgets/tripStepSelectBox_widget.dart';
+import 'package:kompas/controller/tripData_controller.dart';
+import 'package:kompas/controller/tripState_controller.dart';
+import 'package:kompas/statics/colors.dart';
+import 'package:kompas/statics/constants.dart';
+import 'package:kompas/widgets/achievementTracker_widget.dart';
+import 'package:kompas/model/tripDatabase.dart';
+import 'package:kompas/widgets/tripStepSelectBox_widget.dart';
 
 /// Displays trip content based on step type
 class TripViewStepSwitch extends StatelessWidget {

--- a/lib/widgets/tripViewStep_widget.dart
+++ b/lib/widgets/tripViewStep_widget.dart
@@ -3,12 +3,12 @@ import 'dart:ui';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:gra_terenowa/controller/tripData_controller.dart';
-import 'package:gra_terenowa/controller/tripState_controller.dart';
-import 'package:gra_terenowa/statics/colors.dart';
-import 'package:gra_terenowa/statics/constants.dart';
-import 'package:gra_terenowa/widgets/tripViewStepButtons_widget.dart';
-import 'package:gra_terenowa/widgets/tripViewStepSwitch_widget.dart';
+import 'package:kompas/controller/tripData_controller.dart';
+import 'package:kompas/controller/tripState_controller.dart';
+import 'package:kompas/statics/colors.dart';
+import 'package:kompas/statics/constants.dart';
+import 'package:kompas/widgets/tripViewStepButtons_widget.dart';
+import 'package:kompas/widgets/tripViewStepSwitch_widget.dart';
 
 class TripViewStep extends StatelessWidget {
   const TripViewStep({

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -15,13 +15,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
-  change_app_package_name:
-    dependency: "direct main"
-    description:
-      name: change_app_package_name
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.0"
   characters:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -15,6 +15,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
+  change_app_package_name:
+    dependency: "direct main"
+    description:
+      name: change_app_package_name
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   characters:
     dependency: transitive
     description:
@@ -95,53 +102,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_web_plugins:
-    dependency: transitive
-    description: flutter
-    source: sdk
-    version: "0.0.0"
-  geolocator:
-    dependency: "direct main"
-    description:
-      name: geolocator
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "8.1.0"
-  geolocator_android:
-    dependency: transitive
-    description:
-      name: geolocator_android
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "3.0.2"
-  geolocator_apple:
-    dependency: transitive
-    description:
-      name: geolocator_apple
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.1"
-  geolocator_platform_interface:
-    dependency: transitive
-    description:
-      name: geolocator_platform_interface
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "4.0.1"
-  geolocator_web:
-    dependency: transitive
-    description:
-      name: geolocator_web
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.1.4"
-  geolocator_windows:
-    dependency: transitive
-    description:
-      name: geolocator_windows
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.1.0"
   get:
     dependency: "direct main"
     description:
@@ -163,13 +123,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.6.3"
   line_icons:
     dependency: "direct main"
     description:
@@ -351,5 +304,5 @@ packages:
     source: hosted
     version: "0.2.0"
 sdks:
-  dart: ">=2.15.0 <3.0.0"
-  flutter: ">=2.8.0"
+  dart: ">=2.14.0 <3.0.0"
+  flutter: ">=2.5.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,4 +1,4 @@
-name: gra_terenowa
+name: kompas
 description: A new Flutter project.
 
 # The following line prevents the package from being accidentally published to
@@ -32,6 +32,7 @@ dependencies:
   get:
   line_icons: ^2.0.1
   cupertino_icons: ^1.0.2
+  change_app_package_name: ^1.0.0
   #TODO: GPS
   #geolocator: ^8.1.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,7 +32,6 @@ dependencies:
   get:
   line_icons: ^2.0.1
   cupertino_icons: ^1.0.2
-  change_app_package_name: ^1.0.0
   #TODO: GPS
   #geolocator: ^8.1.0
 

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -8,7 +8,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:gra_terenowa/main.dart';
+import 'package:kompas/main.dart';
 
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {

--- a/web/index.html
+++ b/web/index.html
@@ -20,10 +20,10 @@
   <!-- iOS meta tags & icons -->
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
-  <meta name="apple-mobile-web-app-title" content="gra_terenowa">
+  <meta name="apple-mobile-web-app-title" content="kompas.sds">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">
 
-  <title>gra_terenowa</title>
+  <title>kompas.sds</title>
   <link rel="manifest" href="manifest.json">
 </head>
 <body>

--- a/web/manifest.json
+++ b/web/manifest.json
@@ -1,6 +1,6 @@
 {
-    "name": "gra_terenowa",
-    "short_name": "gra_terenowa",
+    "name": "kompas.sds",
+    "short_name": "kompas.sds",
     "start_url": ".",
     "display": "standalone",
     "background_color": "#0175C2",


### PR DESCRIPTION
fixes #14 

Changes:

- Visible app name changed to kompas.sds
- Package name changed to pl.sds.kompas - here the convention is to use the revert domain name followed by the app name
- Changed the repository name in GitHub to kompas.sds
- Since the firebase is empty, a new project with the desired name will be created once we start using it